### PR TITLE
fix: Jwt메소드 분리

### DIFF
--- a/src/main/java/org/example/securityjwttemplate/common/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/org/example/securityjwttemplate/common/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package org.example.securityjwttemplate.common.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.example.securityjwttemplate.common.exception.CommonErrorCode;
+import org.example.securityjwttemplate.common.response.ApiResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    // 권한 부여 실패(로그인은 되어있지만 ROLE_ADMIN만 접근 가능한 페이지에 ROLE_USER가 요청한 경우)
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+        ApiResponse<Void> errorResponse = ApiResponse.error(CommonErrorCode.ACCESS_DENIED);
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}
+

--- a/src/main/java/org/example/securityjwttemplate/common/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/example/securityjwttemplate/common/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package org.example.securityjwttemplate.common.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.example.securityjwttemplate.common.exception.CommonErrorCode;
+import org.example.securityjwttemplate.common.response.ApiResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+// JwtAuthenticationEntryPoint가 없으면 인증실패시 시큐리티가 소셜로그인으로 리다이렉트
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ApiResponse<?> error = ApiResponse.error(CommonErrorCode.UNAUTHORIZED);
+
+        response.getWriter().write(objectMapper.writeValueAsString(error));
+    }
+}

--- a/src/main/java/org/example/securityjwttemplate/common/jwt/JwtBlacklistService.java
+++ b/src/main/java/org/example/securityjwttemplate/common/jwt/JwtBlacklistService.java
@@ -1,0 +1,28 @@
+package org.example.securityjwttemplate.common.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.example.securityjwttemplate.domain.users.repository.RedisRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtBlacklistService {
+
+    private final RedisRepository redisRepository;
+
+    /**
+     * 토큰이 블랙리스트에 존재하는지 확인
+     */
+    public boolean isBlacklisted(String token) {
+        return redisRepository.validateKey(token);
+    }
+
+    /**
+     * 블랙리스트에 토큰을 등록
+     * @param token 블랙리스트로 처리할 토큰
+     * @param expirationMillis 만료 시간(ms)
+     */
+    public void addToBlacklist(String token, long expirationMillis) {
+        redisRepository.saveBlackListToken(token, expirationMillis);
+    }
+}

--- a/src/main/java/org/example/securityjwttemplate/common/jwt/JwtConstants.java
+++ b/src/main/java/org/example/securityjwttemplate/common/jwt/JwtConstants.java
@@ -1,0 +1,13 @@
+package org.example.securityjwttemplate.common.jwt;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class JwtConstants {
+    public static final String HEADER_AUTHORIZATION = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
+    public static final String CLAIM_USER_ROLE = "userRole";
+    public static final String CLAIM_JTI = "jti";
+}
+

--- a/src/main/java/org/example/securityjwttemplate/common/jwt/JwtExtractor.java
+++ b/src/main/java/org/example/securityjwttemplate/common/jwt/JwtExtractor.java
@@ -1,0 +1,32 @@
+package org.example.securityjwttemplate.common.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+import static org.example.securityjwttemplate.common.jwt.JwtConstants.HEADER_AUTHORIZATION;
+import static org.example.securityjwttemplate.common.jwt.JwtConstants.TOKEN_PREFIX;
+
+@Component
+public class JwtExtractor {
+
+    /**
+     * HTTP 요청 헤더에서 Bearer 토큰 추출
+     */
+    public String extractToken(HttpServletRequest request) {
+        String bearer = request.getHeader(HEADER_AUTHORIZATION);
+        if (bearer != null && bearer.startsWith(TOKEN_PREFIX)) {
+            return bearer.substring(TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+
+    /**
+     * RefreshToken 요청 헤더에서 Bearer 토큰 추출
+     */
+    public String extractToken(String bearerHeader) {
+        if (bearerHeader != null && bearerHeader.startsWith(TOKEN_PREFIX)) {
+            return bearerHeader.substring(TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/example/securityjwttemplate/common/jwt/JwtFilter.java
+++ b/src/main/java/org/example/securityjwttemplate/common/jwt/JwtFilter.java
@@ -6,7 +6,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.securityjwttemplate.domain.users.repository.RedisRepository;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -21,41 +20,49 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
-	private final JwtUtil jwtUtil;
-	private final RedisRepository redisRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final JwtExtractor jwtExtractor;
+	private final JwtBlacklistService jwtBlacklistService;
 
 	@Override
-	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-									FilterChain filterChain) throws ServletException, IOException {
+	protected void doFilterInternal(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			FilterChain filterChain
+	) throws ServletException, IOException {
 
-		String token = jwtUtil.extractToken(request);
+		String token = jwtExtractor.extractToken(request);
 
-		// JWT 블랙리스트 검증
-		if(redisRepository.validateKey(token)){
-			response.sendError(HttpServletResponse.SC_UNAUTHORIZED,"이미 로그아웃된 아이디입니다.");
+		if (token == null) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		// 블랙리스트 토큰인지 확인
+		if (jwtBlacklistService.isBlacklisted(token)) {
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "이미 로그아웃된 토큰입니다.");
 			return;
 		}
 
 		try {
-			if(jwtUtil.validateToken(token)){
-				// id 혹은 UserRole 검증
-				UserAuth userAuth = jwtUtil.extractUserAuth(token);
+			if (jwtTokenProvider.validateToken(token)) {
+				UserAuth userAuth = jwtTokenProvider.getUserAuth(token);
 
 				List<SimpleGrantedAuthority> authorities = List.of(
 						new SimpleGrantedAuthority("ROLE_" + userAuth.getUserRole().name())
 				);
 
-				UsernamePasswordAuthenticationToken authToken =		//userAuth,null,authorities
-						new UsernamePasswordAuthenticationToken(userAuth,null, authorities);
+				UsernamePasswordAuthenticationToken authentication =
+						new UsernamePasswordAuthenticationToken(userAuth, null, authorities);
 
-				SecurityContextHolder.getContext().setAuthentication(authToken);
+				SecurityContextHolder.getContext().setAuthentication(authentication);
 			}
 		} catch (Exception e) {
 			log.error("JWT 인증 처리 중 예외 발생", e);
-			response.sendError(HttpServletResponse.SC_UNAUTHORIZED,"유효하지 않은 접근입니다.");
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
 			return;
 		}
 
-		filterChain.doFilter(request,response);
+		filterChain.doFilter(request, response);
 	}
 }

--- a/src/main/java/org/example/securityjwttemplate/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/example/securityjwttemplate/common/jwt/JwtTokenProvider.java
@@ -1,0 +1,110 @@
+package org.example.securityjwttemplate.common.jwt;
+
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.example.securityjwttemplate.domain.users.entity.UserRole;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.example.securityjwttemplate.common.jwt.JwtConstants.*;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+	@Value("${jwt.secret}")
+	private String secretKey;
+
+	@Value("${jwt.access-token-expiration}")
+	private long accessTokenExpiration;
+
+	@Value("${jwt.refresh-token-expiration}")
+	private long refreshTokenExpiration;
+
+	private Key getSigningKey() {
+		return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+	}
+
+	/**
+	 * 액세스 토큰 생성
+	 */
+	public String createAccessToken(Long userId, UserRole role) {
+		return buildToken(userId, role, accessTokenExpiration, false);
+	}
+
+	/**
+	 * 리프레시 토큰 생성 (JTI 포함)
+	 */
+	public String createRefreshToken(Long userId, UserRole role) {
+		return buildToken(userId, role, refreshTokenExpiration, true);
+	}
+
+	/**
+	 * 토큰 유효성 검사
+	 */
+	public boolean validateToken(String token) {
+		try {
+			parseClaims(token);
+			return true;
+		} catch (ExpiredJwtException e) {
+			log.warn("JWT 만료됨");
+		} catch (JwtException | IllegalArgumentException e) {
+			log.warn("유효하지 않은 JWT: {}", e.getMessage());
+		}
+		return false;
+	}
+
+	/**
+	 * 토큰에서 사용자 정보 추출
+	 */
+	public UserAuth getUserAuth(String token) {
+		Claims claims = parseClaims(token);
+		Long userId = Long.parseLong(claims.getSubject());
+		UserRole userRole = UserRole.valueOf(claims.get(CLAIM_USER_ROLE, String.class));
+		return new UserAuth(userId, userRole);
+	}
+
+	/**
+	 * 토큰에서 JTI 추출
+	 */
+	public String getJti(String token) {
+		return parseClaims(token).get(CLAIM_JTI, String.class);
+	}
+
+	/**
+	 * 남은 만료 시간 조회
+	 */
+	public long getExpiration(String token) {
+		return parseClaims(token).getExpiration().getTime() - System.currentTimeMillis();
+	}
+
+	// 내부 공통 메서드
+	private String buildToken(Long userId, UserRole role, long expiration, boolean includeJti) {
+		JwtBuilder builder = Jwts.builder()
+				.setSubject(String.valueOf(userId))
+				.claim(CLAIM_USER_ROLE, role.name())
+				.setIssuedAt(new Date())
+				.setExpiration(new Date(System.currentTimeMillis() + expiration));
+
+		if (includeJti) {
+			builder.claim(CLAIM_JTI, UUID.randomUUID().toString());
+		}
+
+		return builder.signWith(getSigningKey()).compact();
+	}
+
+	private Claims parseClaims(String token) {
+		return Jwts.parserBuilder()
+				.setSigningKey(getSigningKey())
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+	}
+}

--- a/src/main/java/org/example/securityjwttemplate/common/response/ApiResponse.java
+++ b/src/main/java/org/example/securityjwttemplate/common/response/ApiResponse.java
@@ -1,0 +1,57 @@
+package org.example.securityjwttemplate.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.example.securityjwttemplate.common.exception.ErrorCode;
+import org.example.securityjwttemplate.common.exception.ErrorResponse;
+import org.springframework.validation.BindingResult;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL) // null인 필드는 Json응답에서 제외, 성공한 요청에는 errors가 필요 없으니 JSON에서 아예 빠지도록 설정
+public class ApiResponse<T> {
+
+    private String status; // "SUCCESS" 또는 "FAIL"
+    private String code;   // S200, U001 등
+    private String message;
+    private T data;        // 성공 시 응답 데이터
+    private List<ErrorResponse.FieldError> errors; // 실패 시 필드 오류 목록
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return ApiResponse.<T>builder()
+                .status("SUCCESS")
+                .code("S200")
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    public static ApiResponse<Void> success(String message) {
+        return success(message, null);
+    }
+
+    public static ApiResponse<Void> error(ErrorCode errorCode) {
+        return ApiResponse.<Void>builder()
+                .status("FAIL")
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .errors(Collections.emptyList())
+                .build();
+    }
+
+    public static ApiResponse<Void> error(ErrorCode errorCode, BindingResult bindingResult) {
+        return ApiResponse.<Void>builder()
+                .status("FAIL")
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .errors(ErrorResponse.FieldError.of(bindingResult))
+                .build();
+    }
+}
+


### PR DESCRIPTION
## 🔗 Issue 번호
- close #10 

## 🛠 작업 내역
- Jwt 메소드 분리

## 🔄 변경 사항
-

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 액세스/리프레시 토큰 생성·검증 기능 추가로 인증 흐름 강화
  - 요청 헤더에서 토큰 추출 지원 및 블랙리스트 기반 로그아웃 처리로 토큰 재사용 차단
  - 표준화된 API 응답 포맷(SUCCESS/FAIL, 코드, 메시지, 오류 목록) 도입으로 응답 일관성 향상
- Refactor
  - 보안 설정에 사용자 정의 401/403 JSON 응답 적용으로 인증/인가 오류 처리 일원화
  - 필터 로직과 책임 분리로 안정성 및 유지보수성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->