### PR TITLE
fix: 공통응답 처리 ApiResponse

### DIFF
--- a/src/main/java/org/example/securityjwttemplate/common/exception/CommonErrorCode.java
+++ b/src/main/java/org/example/securityjwttemplate/common/exception/CommonErrorCode.java
@@ -7,9 +7,14 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum CommonErrorCode implements ErrorCode {
-	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "입력값이 올바르지 않습니다."),
-	LOCK_FAILED(HttpStatus.BAD_REQUEST,"C002","락 획득 실패"),
-	LOCK_INTERRUPTED(HttpStatus.BAD_REQUEST,"C003","락이 인터럽트 됐습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C000", "서버 내부 오류입니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "입력값이 올바르지 않습니다."),
+    MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "C002", "필수 파라미터가 누락되었습니다."),
+    INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "C003", "요청 형식이 올바르지 않습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C004", "허용되지 않은 HTTP 메서드입니다."),
+    UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "C005", "지원하지 않는 미디어 타입입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "C006", "인증이 필요합니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "C007", "접근 권한이 없습니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/org/example/securityjwttemplate/common/exception/ErrorResponse.java
+++ b/src/main/java/org/example/securityjwttemplate/common/exception/ErrorResponse.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -22,25 +21,25 @@ public class ErrorResponse {
 	private final LocalDateTime timestamp;
 	private final List<FieldError> errors;
 
-	public static ErrorResponse of(ErrorCode errorCode) {
-		return ErrorResponse.builder()
-			.status(errorCode.getStatus())
-			.code(errorCode.getCode())
-			.message(errorCode.getMessage())
-			.timestamp(LocalDateTime.now())
-			.errors(Collections.emptyList())
-			.build();
-	}
-
-	public static ErrorResponse of(ErrorCode errorCode, BindingResult bindingResult) {
-		return ErrorResponse.builder()
-			.status(errorCode.getStatus())
-			.code(errorCode.getCode())
-			.message(errorCode.getMessage())
-			.timestamp(LocalDateTime.now())
-			.errors(FieldError.of(bindingResult))
-			.build();
-	}
+//	public static ErrorResponse of(ErrorCode errorCode) {
+//		return ErrorResponse.builder()
+//			.status(errorCode.getStatus())
+//			.code(errorCode.getCode())
+//			.message(errorCode.getMessage())
+//			.timestamp(LocalDateTime.now())
+//			.errors(Collections.emptyList())
+//			.build();
+//	}
+//
+//	public static ErrorResponse of(ErrorCode errorCode, BindingResult bindingResult) {
+//		return ErrorResponse.builder()
+//			.status(errorCode.getStatus())
+//			.code(errorCode.getCode())
+//			.message(errorCode.getMessage())
+//			.timestamp(LocalDateTime.now())
+//			.errors(FieldError.of(bindingResult))
+//			.build();
+//	}
 
 	@Getter
 	@AllArgsConstructor


### PR DESCRIPTION
## 🔗 Issue 번호
- close #11

## 🛠 작업 내역
-

## 🔄 변경 사항
-

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 다양한 예외 상황에 대한 표준화된 에러 코드 추가: 내부 서버 오류, 필수 파라미터 누락, 잘못된 JSON 형식, 허용되지 않은 메서드, 지원하지 않는 미디어 타입, 인증 필요, 접근 권한 없음 등.
- Refactor
  - 전역 예외 응답을 단일 ApiResponse 에러 포맷으로 통일하여 일관된 응답 구조 제공.
  - 검증 오류 및 요청 파라미터 누락도 동일 포맷으로 반환.
  - 기존 락 관련 에러 코드는 제거.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->