### PR TITLE
fix: #35 user를 조회할때 deleted_at이 null이면 조회하지 않도록 sql문 개선

### DIFF
--- a/src/main/java/org/example/securityjwttemplate/common/entity/BaseEntity.java
+++ b/src/main/java/org/example/securityjwttemplate/common/entity/BaseEntity.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import org.example.securityjwttemplate.common.exception.BizException;
 import org.example.securityjwttemplate.common.exception.CommonErrorCode;
+import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -17,6 +18,7 @@ import lombok.Getter;
 
 @Getter
 @MappedSuperclass
+@Where(clause = "deleted_at IS NULL")
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 	@CreatedDate

--- a/src/main/java/org/example/securityjwttemplate/domain/users/service/UserService.java
+++ b/src/main/java/org/example/securityjwttemplate/domain/users/service/UserService.java
@@ -76,7 +76,7 @@ public class UserService {
 	@Transactional
 	public void deleteUser(UserAuth userAuth) {
 		User user = userRepository.findByIdOrElseThrow(userAuth.getId());
-		user.softDelete();
+		user.softDelete(user.getId());
 		// 추후 유저관련 내용 삭제 로직 추가
 	}
 }


### PR DESCRIPTION
## 🔗 Issue 번호
- close #35 
- close #36 

## 🛠 작업 내역
-

## 🔄 변경 사항
-

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 소프트 삭제된 사용자 데이터가 조회 결과에서 자동으로 제외되도록 개선했습니다.
  * 사용자 삭제 기능의 동작 흐름을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->